### PR TITLE
Rename `dump_target.kind` to `type`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ An ansible role which configures kdump.
 ## Role Variables
 
 **dump_target**: Can be specified to write vmcore to a location that is not in
-the root file system. If `kind` is `raw` or a filesystem type, location points
+the root file system. If `type` is `raw` or a filesystem type, location points
 to a partition (by device node name, label, or uuid). For example:
 
 ```yaml
 dump_target:
-  kind: raw
+  type: raw
   location: /dev/sda1
 ```
 
@@ -19,22 +19,22 @@ or for an `ext4` filesystem:
 
 ```yaml
 dump_target:
-  kind: ext4
+  type: ext4
   location: "12e3e25f-534e-4007-a40c-e7e080a933ad"
 ```
 
-If `kind` is `ssh`, location points to a server:
+If `type` is `ssh`, location points to a server:
 example:
 
 ```yaml
-  kind: ssh
+  type: ssh
   location: user@example.com
 ```
 
 Similarly for `nfs`, `location` points to an nfs server:
 
 ```yaml
-  kind: nfs
+  type: nfs
   location: nfs.example.com
 ```
 

--- a/templates/kdump.conf.j2
+++ b/templates/kdump.conf.j2
@@ -2,7 +2,7 @@
 # Last modified: {{ ansible_date_time.date }} {{ ansible_date_time.time }}
 
 {% if dump_target %}
-{{ dump_target.kind }} {{ dump_target.location }}
+{{ dump_target.type }} {{ dump_target.location }}
 {% endif %}
 path {{ path }}
 {% if core_collector %}


### PR DESCRIPTION
`kind` is too obscure.

Fixes #2