### PR TITLE
Add ssh support for Kdump role

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,6 @@ dump_target: null
 path: /var/crash
 core_collector: null
 system_action: reboot
+ssh_dump_user: null
+ssh_dump_server: null
+sshkey: /root/.ssh/kdump_id_rsa

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,9 @@
   command: cat /sys/kernel/kexec_crash_size
   register: kexec_crash_size
 
+- include_tasks: ssh.yml
+  when: dump_target.kind == "ssh"
+
 - name: Generate /etc/kdump.conf
   template:
     src: kdump.conf.j2

--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -1,0 +1,17 @@
+---
+- stat: path="{{ sshkey }}"
+  register: sshkey_stats
+
+- command: "/usr/bin/ssh-keygen -t rsa -f {{ sshkey }} -N '' "
+  when: sshkey_stats.stat.exists == False
+
+- name: cat file to register
+  shell: cat {{ sshkey }}.pub
+  register: keydata
+
+- name:
+  authorized_key:
+    user: "{{ ssh_dump_user }}"
+    key: "{{ keydata.stdout }}"
+    state: present
+  delegate_to: "{{ ssh_dump_server }}"

--- a/templates/kdump.conf.j2
+++ b/templates/kdump.conf.j2
@@ -4,6 +4,11 @@
 {% if dump_target %}
 {{ dump_target.kind }} {{ dump_target.location }}
 {% endif %}
+
+{% if dump_target.kind == "ssh" and sshkey != '/root/.ssh/kdump_id_rsa' %}
+sshkey {{ sshkey }}
+{% endif %}
+
 path {{ path }}
 {% if core_collector %}
 core_collector {{ core_collector }}

--- a/test/test_ssh.yml
+++ b/test/test_ssh.yml
@@ -1,0 +1,12 @@
+
+- name: Ensure that the rule runs with default parameters
+  hosts: all
+  vars:
+    ssh_dump_user: root
+    ssh_dump_server: 192.168.124.1
+    dump_target:
+      kind: ssh
+      location: "{{ ssh_dump_user }}@{{ ssh_dump_server }}"
+
+  roles:
+    - kdump


### PR DESCRIPTION
There are two commits. The 1st commit is to add ssh support for kdump role. The 2nd one is adding example code for testing ssh. While customer has to specify ssh_dump_server explicitly, otherwise the test/test_ssh.yml should fail. It may not be fit for CI testing, just an example.