### PR TITLE
Fix lint errors, fix checkmode

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   license: MIT
   min_ansible_version: 2.4
   platforms:
-  - name: Fedora
-    versions: [ 27, 28 ]
-  - name: EL
-    versions: [ 6, 7 ]
+    - name: Fedora
+      versions: [ 27, 28 ]
+    - name: EL
+      versions: [ 6, 7 ]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,8 @@
     state: present
 
 - name: Find out reserved memory for the crash kernel
-  command: cat /sys/kernel/kexec_crash_size
+  slurp:
+    src: /sys/kernel/kexec_crash_size
   register: kexec_crash_size
 
 - include_tasks: ssh.yml
@@ -18,7 +19,7 @@
     src: kdump.conf.j2
     dest: /etc/kdump.conf
     backup: yes
-  when: kexec_crash_size.stdout|int > 0
+  when: kexec_crash_size.content|b64decode|int > 0
   notify: restart kdump
 
 - name: Generate /etc/sysconfig/kdump
@@ -26,5 +27,5 @@
     src: kdump.j2
     dest: /etc/sysconfig/kdump
     backup: yes
-  when: kexec_crash_size.stdout|int > 0
+  when: kexec_crash_size.content|b64decode|int > 0
   notify: restart kdump

--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -1,15 +1,17 @@
 ---
-- stat: path="{{ kdump_sshkey }}"
+- name: Check whether key exists
+  stat: path="{{ kdump_sshkey }}"
   register: sshkey_stats
 
-- command: "/usr/bin/ssh-keygen -t rsa -f {{ kdump_sshkey }} -N '' "
-  when: sshkey_stats.stat.exists == False
+- name: Create key
+  command: "/usr/bin/ssh-keygen -t rsa -f {{ kdump_sshkey }} -N '' "
+  when: not sshkey_stats.stat.exists
 
-- name: cat file to register
+- name: Cat file to register
   shell: cat {{ kdump_sshkey }}.pub
   register: keydata
 
-- name:
+- name: Add key to authorized keys
   authorized_key:
     user: "{{ kdump_ssh_user }}"
     key: "{{ keydata.stdout }}"

--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -7,13 +7,14 @@
   command: "/usr/bin/ssh-keygen -t rsa -f {{ kdump_sshkey }} -N '' "
   when: not sshkey_stats.stat.exists
 
-- name: Cat file to register
-  shell: cat {{ kdump_sshkey }}.pub
+- name: Fetch key
+  slurp:
+    src: "{{ kdump_sshkey }}.pub"
   register: keydata
 
 - name: Add key to authorized keys
   authorized_key:
     user: "{{ kdump_ssh_user }}"
-    key: "{{ keydata.stdout }}"
+    key: "{{ keydata.content|b64decode }}"
     state: present
   delegate_to: "{{ kdump_ssh_server }}"


### PR DESCRIPTION
Fixes indentation in role's metadata:
--> Executing Yamllint on files found in kdump/...
    meta/main.yml
      9:3       error    wrong indentation: expected 4 but found 2  (indentation)

Fixes 'Find out reserved memory for the crash kernel' task to
never report 'changed' status:
--> Executing Ansible Lint on kdump/tests/tests_default.yml...
    [ANSIBLE0012] Commands should not change things if nothing needs doing
    kdump/tests/roles/kdump/tasks/main.yml:7
    Task/Handler: Find out reserved memory for the crash kernel