### PR TITLE
Synchronize files from linux-system-roles/template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,30 @@
+# SPDX-License-Identifier: MIT
 ---
+dist: xenial
 language: python
+env:
+  global:
+    - LSR_ANSIBLES='ansible==2.7.* ansible==2.8.* ansible==2.9.*'
+    - LSR_MSCENARIOS='default'
+matrix:
+  include:
+    - python: 2.6
+      dist: trusty
+    - python: 2.7
+    - python: 3.5
+    - python: 3.6
+    - python: 3.7
+    - python: 3.8
+    - python: 3.8-dev
+
 services:
   - docker
+
+before_install:
+  - ./.travis/preinstall
+
 install:
-  - pip install molecule docker
+  - pip install tox tox-travis
+
 script:
-  - molecule --version
-  - ansible --version
-  - molecule lint
-  - molecule syntax
-  - molecule test
+  - ./.travis/runtox

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 # Molecule managed
 
 {% if item.registry is defined %}

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 ---
 dependency:
   name: galaxy
@@ -9,10 +10,10 @@ lint:
     config-file: molecule/default/yamllint.yml
 platforms:
   - name: centos-6
-    image: linuxsystemroles/centos-6
+    image: docker.io/linuxsystemroles/centos-6
     privileged: true
   - name: centos-7
-    image: linuxsystemroles/centos-7
+    image: docker.io/linuxsystemroles/centos-7
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true

--- a/molecule/default/yamllint.yml
+++ b/molecule/default/yamllint.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 ---
 extends: default
 rules:
@@ -7,6 +8,5 @@ rules:
   brackets:
     max-spaces-inside: 1
     level: error
-  line-length: disable
   truthy: disable
   document-start: disable


### PR DESCRIPTION
This PR propagates files from [linux-system-roles/template](https://github.com/linux-system-roles/template) which should be in sync across [linux-system-roles](https://github.com/linux-system-roles) repos. In case of changing affected files via pushing to this PR, please do not forget also to push the changes to [linux-system-roles/template](https://github.com/linux-system-roles/template) repo.

Revision: [`367b19f14391ffdb0ff055e8fe6fe3894f070980`](https://github.com/linux-system-roles/template/tree/367b19f14391ffdb0ff055e8fe6fe3894f070980)

CC: @i386x, @pcahyna, @richm