### PR TITLE
Get rid of the extra final newline in string

### DIFF
--- a/tests/tests_ssh.yml
+++ b/tests/tests_ssh.yml
@@ -15,7 +15,7 @@
     - include_role:
         name: linux-system-roles.kdump
       vars:
-        kdump_ssh_user: |
+        kdump_ssh_user: >-
           {{ hostvars[kdump_ssh_server_outside]['ansible_user_id'] }}
         # This is the outside address. Ansible will connect to it to
         # copy the ssh key.


### PR DESCRIPTION
Use the `-` chomping indicator to indicate that the trailing newline is not intended as a part of the string. https://yaml.org/spec/1.1/#chomping/

The trailing newline was causing an actual problem in the test.

Also use the `>` folded style, which is more appropriate here than the `|` literal style.