### PR TITLE
Add `KDUMP_BOOTDIR="/boot"`to `/etc/sysconfig/kdump` for RedHat oses <7

### DIFF
--- a/templates/kdump.j2
+++ b/templates/kdump.j2
@@ -6,7 +6,7 @@ KDUMP_COMMANDLINE_REMOVE="hugepages hugepagesz slub_debug quiet"
 
 KDUMP_COMMANDLINE_APPEND="irqpoll nr_cpus=1 reset_devices cgroup_disable=memory mce=off numa=off udev.children-max=2 panic=10 rootflags=nofail acpi_no_memhotplug transparent_hugepage=never"
 
-{% elif ansible_distribution == 'RedHat' and ansible_distribution_version|int < 7 %}
+{% elif ansible_os_family == 'RedHat' and ansible_distribution_version|int < 7 %}
 
 KDUMP_COMMANDLINE_APPEND="irqpoll nr_cpus=1 reset_devices cgroup_disable=memory mce=off acpi_no_memhotplug"
 


### PR DESCRIPTION
Fix the kdump.j2 template to work on CentOS 6 too by changing `ansible_distribution == 'RedHat'` to `ansible_os_family == 'RedHat'`.

Enable kdump and perform a reboot on RHEL 6 because by default RHEL 6 image in the CI does not have memory reserved for kdump. This issue only happens with the image, a default installation of RHEL 6 has memory reserved, so fixing it in tests only.

For tests_ssh.yml, manually specify the `netdev` variable in `/sbin/mkdumprd` because by default mkdumprd does not expect the host to connect to itself via SSH. This is an issue with the CI only because the test is single-host.