### PR TITLE
Add tags to tests

### DIFF
--- a/tests/tests_default_wrapper.yml
+++ b/tests/tests_default_wrapper.yml
@@ -1,6 +1,8 @@
 ---
 - name: Create static inventory from hostvars
   hosts: all
+  tags:
+    - 'tests::slow'
   tasks:
     - name: create temporary file
       tempfile:
@@ -17,10 +19,14 @@
 
 
 - name: Run tests_default.yml normally
+  tags:
+    - 'tests::slow'
   import_playbook: tests_default.yml
 
 - name: Run tests_default.yml in check_mode
   hosts: all
+  tags:
+    - 'tests::slow'
   tasks:
     - name: Run ansible-playbook with tests_default.yml in check mode
       command: >

--- a/tests/tests_ssh.yml
+++ b/tests/tests_ssh.yml
@@ -7,6 +7,7 @@
     # Can be set to localhost if the control node is being used as the
     # kdump target. This requires sshd to be running on the control
     # node, though.
+    # In this case uncomment the tests::multihost_localhost tag below.
     # Setting it to inventory_hostname uses the managed node itself as
     # the kdump target. This makes the the test entirely single-host,
     # but is less realistic, as in practice a host can not dump core
@@ -24,6 +25,18 @@
       else
       hostvars[kdump_test_ssh_server_outside]['ansible_default_ipv4']['address']
       }}
+
+  # This test may execute some tasks on localhost and rely on
+  # localhost being a different host than the managed host
+  # (localhost is being used as a second host in multihost
+  # scenario). This would also mean that localhost would have to
+  # be capable enough (not just a container - must be running a
+  # sshd).
+  # This applies only when kdump_test_ssh_server_outside is set to
+  # localhost. In that case, uncomment the lines below and the
+  # corresponding line in tests_ssh_wrapper.yml
+  # tags:
+  #   - 'tests::multihost_localhost'
 
   tasks:
     - name: gather facts from {{ kdump_test_ssh_server_outside }}

--- a/tests/tests_ssh_wrapper.yml
+++ b/tests/tests_ssh_wrapper.yml
@@ -1,6 +1,8 @@
 ---
 - name: Create static inventory from hostvars
   hosts: all
+  tags:
+    - 'tests::slow'
   tasks:
     - name: create temporary file
       tempfile:
@@ -17,10 +19,16 @@
 
 
 - name: Run tests_ssh.yml normally
+  tags:
+    - 'tests::slow'
   import_playbook: tests_ssh.yml
 
 - name: Run tests_ssh.yml in check_mode
   hosts: all
+  tags:
+    - 'tests::slow'
+    # uncomment the line below if uncommenting it in tests_ssh.yml
+    # - 'tests::multihost_localhost'
   tasks:
     - name: Run ansible-playbook with tests_ssh.yml in check mode
       command: |


### PR DESCRIPTION
Updated version of #28. 

The commit sequence is taken mostly from #28 with additional commits on top. It will be squashed to less commits when merging or before.

This change is for the benefit of quick downstream testing when tests run against localhost (a machine in CI) and should have no functional impact on upstream.