### PR TITLE
tag tests for basic runs; do service save/restore

### DIFF
--- a/ansible_pytest_extra_requirements.txt
+++ b/ansible_pytest_extra_requirements.txt
@@ -1,7 +1,3 @@
 # SPDX-License-Identifier: MIT
 
 # ansible and dependencies for all supported platforms
-ansible ; python_version > "2.6"
-ansible<2.7 ; python_version < "2.7"
-idna<2.8 ; python_version < "2.7"
-PyYAML<5.1 ; python_version < "2.7"

--- a/tests/tasks/get_services_state.yml
+++ b/tests/tasks/get_services_state.yml
@@ -1,0 +1,4 @@
+- name: Get initial state of services
+  tags: tests::cleanup
+  service_facts:
+  register: initial_state

--- a/tests/tasks/restore_services_state.yml
+++ b/tests/tasks/restore_services_state.yml
@@ -1,0 +1,22 @@
+- block:
+    - name: load common vars
+      include_vars:
+        file: ../vars/commonvars.yml
+
+    - name: Get final state of services
+      service_facts:
+      register: final_state
+
+    - name: Restore state of services
+      service:
+        name: "{{ item }}"
+        state: "{{ 'started' if
+                   initial_state.ansible_facts.services[sname]['state']
+                   == 'running' else 'stopped' }}"
+      when:
+        - sname in final_state.ansible_facts.services
+        - sname in initial_state.ansible_facts.services
+      vars:
+        sname: "{{ item + '.service' }}"
+      with_items: "{{ restore_services }}"
+  tags: tests::cleanup

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -1,5 +1,13 @@
-- name: Ensure that the rule runs with default parameters
+- name: Ensure that the role runs with default parameters
   hosts: all
 
   roles:
     - linux-system-roles.kdump
+
+  pre_tasks:
+    - name: Import tasks
+      import_tasks: tasks/get_services_state.yml
+
+  post_tasks:
+    - name: Import tasks
+      import_tasks: tasks/restore_services_state.yml

--- a/tests/tests_default_wrapper.yml
+++ b/tests/tests_default_wrapper.yml
@@ -1,6 +1,8 @@
 ---
 - name: Create static inventory from hostvars
   hosts: all
+  tags:
+    - 'tests::slow'
   tasks:
     - name: create temporary file
       tempfile:
@@ -17,10 +19,14 @@
 
 
 - name: Run tests_default.yml normally
+  tags:
+    - 'tests::slow'
   import_playbook: tests_default.yml
 
 - name: Run tests_default.yml in check_mode
   hosts: all
+  tags:
+    - 'tests::slow'
   tasks:
     - name: Run ansible-playbook with tests_default.yml in check mode
       command: >

--- a/tests/tests_ssh.yml
+++ b/tests/tests_ssh.yml
@@ -24,6 +24,13 @@
       else
       hostvars[kdump_test_ssh_server_outside]['ansible_default_ipv4']['address']
       }}
+  tags:
+    # this test executes some tasks on localhost and relies on
+    # localhost being a different host than the managed host
+    # (localhost is being used as a second host in multihost
+    # scenario). This also means that localhost must be capable
+    # enough (not just a container - must be runnign a sshd).
+    - 'tests::multihost_localhost'
 
   tasks:
     - name: gather facts from {{ kdump_test_ssh_server_outside }}

--- a/tests/tests_ssh_wrapper.yml
+++ b/tests/tests_ssh_wrapper.yml
@@ -1,6 +1,8 @@
 ---
 - name: Create static inventory from hostvars
   hosts: all
+  tags:
+    - 'tests::slow'
   tasks:
     - name: create temporary file
       tempfile:
@@ -17,10 +19,15 @@
 
 
 - name: Run tests_ssh.yml normally
+  tags:
+    - 'tests::slow'
   import_playbook: tests_ssh.yml
 
 - name: Run tests_ssh.yml in check_mode
   hosts: all
+  tags:
+    - 'tests::slow'
+    - 'tests::multihost_localhost'
   tasks:
     - name: Run ansible-playbook with tests_ssh.yml in check mode
       command: |

--- a/tests/vars/commonvars.yml
+++ b/tests/vars/commonvars.yml
@@ -1,0 +1,2 @@
+restore_services:
+  - kdump


### PR DESCRIPTION
tag tests so that we can exclude some of them when running
under certain conditions like basic smoke test, single node, or
to exclude cleanup tasks if we don't need them
save state of services so that we can restore them during cleanup