### PR TITLE
Remove python-26 environment from tox testing

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -42,37 +42,3 @@ jobs:
           38) toxenvs="${toxenvs},coveralls,custom" ;;
           esac
           TOXENV="$toxenvs" lsr_ci_runtox
-  python-26:
-    runs-on: ubuntu-16.04
-    env:
-      PY26URL: https://storage.googleapis.com/travis-ci-language-archives/python/binaries/ubuntu/14.04/x86_64/python-2.6.tar.bz2
-      PY26TARFILE: "python-2.6.tar.bz2"
-      PY26VENVPATH: "/home/travis/virtualenv/python2.6"
-      VIRTUAL_ENV_DISABLE_PROMPT: "true"
-    steps:
-      - name: checkout PR
-        uses: actions/checkout@v2
-      - name: Install python, dependencies
-        run: |
-          set -euo pipefail
-          curl -sSf --retry 5 -o "$PY26TARFILE" "$PY26URL"
-          sudo tar xjf "$PY26TARFILE" --directory /
-          myuid=$(id -u)
-          mygid=$(id -g)
-          sudo chown -H -R $myuid:$mygid "$PY26VENVPATH"
-          source "$PY26VENVPATH/bin/activate"
-          set -x
-          python --version
-          pip --version
-          sudo apt-get update
-          sudo apt-get install git
-          pip install 'tox<3' 'virtualenv==15.*' 'pluggy==0.5.*' \
-          "$TOX_LSR"
-          lsr_ci_preinstall
-          pip list
-      - name: Run tox tests
-        run: |
-          set -euo pipefail
-          source "$PY26VENVPATH/bin/activate"
-          set -x
-          tox -e py26,coveralls26,custom


### PR DESCRIPTION
This role does not currently need tox testing on python 2.6, which
is primarily for modules that run on EL6 managed hosts.  Testing on
python 2.6 is problematic due to the age and supportability, which
causes false positive tests, cluttering up the status and adding
noise.  Therefore, we should get rid of the test.

If the role in the future needs to test with python 2.6, see
https://github.com/linux-system-roles/lsr-gh-action-py26