### PR TITLE
Add reboot required

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,24 @@ with options depending on the `kdump_target.type`.
   The action that is performed when dumping the core file fails. Can be
   `reboot`, `halt`, `poweroff`, or `shell`.
 
+**kdump_reboot_ok**: If you run the role on a managed node that does not have
+memory reserved for crash kernel, i.e. the file `/sys/kernel/kexec_crash_size`
+contains `0`, it might be required to reboot the managed node to configure kdump.
+
+By default, the role does not reboot the managed node. If a managed node
+requires reboot, the role sets the `kdump_reboot_required` fact and fails, so
+that the user can reboot the managed node when needed. If you want the role to
+reboot the system if required, set this variable to `true`. You do not need to
+re-execute the role after boot.
+
+Default: `false`
+
+## Ansible Facts Returned by the Role
+
+**kdump_reboot_required**: The role sets this fact if the managed node requires
+reboot to complete kdump configuration. Re-execute the role after boot to ensure
+that kdump is working.
+
 ## License
 
 MIT

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,4 @@ kdump_system_action: reboot
 kdump_ssh_user: null
 kdump_ssh_server: null
 kdump_sshkey: /root/.ssh/kdump_id_rsa
+kdump_reboot_ok: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,3 +3,6 @@
   service:
     name: kdump
     state: restarted
+  when:
+    - not __kdump_service_start.changed | d(false)
+    - not kdump_reboot_required

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,12 +4,13 @@
     name: kexec-tools
     state: present
 
-- name: Find out reserved memory for the crash kernel
-  slurp:
-    src: /sys/kernel/kexec_crash_size
-  register: kexec_crash_size
+- name: Ensure that kdump is enabled
+  service:
+    name: kdump
+    enabled: true
 
-- include_tasks: ssh.yml
+- name: Include SSH tasks
+  include_tasks: ssh.yml
   when:
     - kdump_target.type | d(none) == 'ssh'
 
@@ -24,7 +25,6 @@
     dest: /etc/kdump.conf
     backup: yes
     mode: "{{ __kdump_conf.stat.mode | d('0644') }}"
-  when: kexec_crash_size.content|b64decode|int > 0
   notify: restart kdump
 
 - name: Get mode of /etc/sysconfig/kdump if it exists
@@ -38,5 +38,46 @@
     dest: /etc/sysconfig/kdump
     backup: yes
     mode: "{{ __sysconfig_kdump.stat.mode | d('0644') }}"
-  when: kexec_crash_size.content|b64decode|int > 0
   notify: restart kdump
+
+- name: Find out reserved memory for the crash kernel
+  slurp:
+    src: /sys/kernel/kexec_crash_size
+  register: kexec_crash_size
+
+- name: Set the kdump_reboot_required fact
+  set_fact:
+    kdump_reboot_required: "{{
+      kexec_crash_size.content | b64decode | int < 1
+    }}"
+
+- name: Fail if reboot is required and kdump_reboot_ok is false
+  fail:
+    msg: >-
+      "Reboot is required to apply changes. Re-execute the role after boot to
+      ensure that kdump is working."
+  when:
+    - kdump_reboot_required | bool
+    - not kdump_reboot_ok
+
+- name: Reboot the managed node
+  reboot:
+  when:
+    - kdump_reboot_required | bool
+    - kdump_reboot_ok | bool
+
+- name: Clear the kdump_reboot_required flag
+  set_fact:
+    kdump_reboot_required: false
+  when:
+    - kdump_reboot_required | bool
+    - kdump_reboot_ok | bool
+
+# This task is for users who run the role after reboot. The handlers do not run
+# in this case, because the role results in not changed state. It is necessary
+# to explicitly start kdump to rebuild initrd.
+- name: Ensure that kdump is started
+  service:
+    name: kdump
+    state: started
+  register: __kdump_service_start

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -1,5 +1,18 @@
 - name: Ensure that the rule runs with default parameters
   hosts: all
-
-  roles:
-    - linux-system-roles.kdump
+  tasks:
+    - name: >-
+        The role requires reboot only on specific systems. Hence running the
+        role in a rescue block to catch when it fails with reboot.
+      block:
+        - name: Run the role. If reboot is not required - the play succeeds.
+          include_role:
+            name: linux-system-roles.kdump
+      rescue:
+        - name: If reboot is required - assert the expected fail message
+          assert:
+            that:
+              - >-
+                'Reboot is required to apply changes.' in
+                ansible_failed_result.msg
+              - kdump_reboot_required | bool

--- a/tests/tests_default_reboot.yml
+++ b/tests/tests_default_reboot.yml
@@ -1,0 +1,10 @@
+- name: Ensure that the rule runs with default parameters
+  hosts: all
+  vars:
+    kdump_reboot_ok: true
+  tags:
+    - tests::reboot
+  tasks:
+    - name: Run the role and reboot if necessary
+      include_role:
+        name: linux-system-roles.kdump

--- a/tests/tests_ssh_reboot.yml
+++ b/tests/tests_ssh_reboot.yml
@@ -43,6 +43,10 @@
       # there.
       location: "{{ kdump_ssh_user }}@{{ kdump_test_ssh_server_inside }}"
 
+    kdump_reboot_ok: true
+  tags:
+    - tests::reboot
+
   # This test may execute some tasks on localhost and rely on
   # localhost being a different host than the managed host
   # (localhost is being used as a second host in multihost
@@ -63,7 +67,7 @@
 
     - name: Print message that this test is skipped on EL 6
       debug:
-        msg: Skipping the test on EL 6 when storing logs over ssh to localhost
+        msg: Skipping the test on EL 6 because control node == managed node
       when:
         - ansible_distribution in ['CentOS','RedHat']
         - ansible_distribution_major_version == '6'
@@ -78,18 +82,6 @@
         - ansible_distribution_major_version == '6'
         - kdump_test_ssh_server_outside == inventory_hostname
 
-    - name: >-
-        The role requires reboot only on specific systems. Hence running the
-        role in a rescue block to catch when it fails with reboot.
-      block:
-        - name: Run the role. If reboot is not required - the play succeeds.
-          include_role:
-            name: linux-system-roles.kdump
-      rescue:
-        - name: If reboot is required - assert the expected fail message
-          assert:
-            that:
-              - >-
-                'Reboot is required to apply changes.' in
-                ansible_failed_result.msg
-              - kdump_reboot_required | bool
+    - name: Run the role and reboot if necessary
+      include_role:
+        name: linux-system-roles.kdump


### PR DESCRIPTION
**Add kdump_reboot_required for systems with kdump disabled by default**

- Systems that do not have kdump enabled might not have the memory reserved for kdump in /sys/kernel/kexec_crash_size. It is necessary to enable kdump and reboot the system to reserve memory and populate /sys/kernel/kexec_crash_size with the required value.
- Add kdump_reboot_required fact and fail if it is set
- Document the kdump_reboot_required flag in README.md
- Add tests/tasks/execute_with_reboot.yml that runs the role with the rescue block to reboot the managed node if necessary and use this task in tests to run the role.
- Do not skip tasks if kexec_crash_size does not contain the required value. Instead,  configure kdump and request reboot to apply the changes

**Fix /sbin/mkdumprd to point netdev to eth0**

Kdump on EL 6 does not support storing logs to localhost via ssh.
Connecting to localhost via ssh is not a common scenario, we have to use
it to make tests single-host, hence I am applying this workaround to fix
tests.
Nothing that the role can do to fix mkdumprd, it is a EL 6 kdump bug.
