### PR TITLE
support gather_facts: false; support setup-snapshot.yml

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,10 @@
 ---
-- name: Install kexec-tools
+- name: Ensure ansible_facts used by role
+  include_tasks: set_vars.yml
+
+- name: Install required packages
   package:
-    name: kexec-tools
+    name: "{{ __kdump_packages }}"
     state: present
 
 - name: Ensure that kdump is enabled

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -1,0 +1,6 @@
+---
+- name: Ensure ansible_facts used by role
+  setup:
+    gather_subset: min
+  when: not ansible_facts.keys() | list |
+    intersect(__kdump_required_facts) == __kdump_required_facts

--- a/tests/setup-snapshot.yml
+++ b/tests/setup-snapshot.yml
@@ -1,0 +1,12 @@
+- hosts: all
+  tasks:
+    - name: Set platform/version specific variables
+      include_role:
+        name: linux-system-roles.kdump
+        tasks_from: set_vars.yml
+        public: true
+
+    - name: Install test packages
+      package:
+        name: "{{ __kdump_packages }}"
+        state: present

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -1,5 +1,6 @@
 - name: Ensure that the rule runs with default parameters
   hosts: all
+  gather_facts: false
   tasks:
     - name: >-
         The role requires reboot only on specific systems. Hence running the

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,3 +3,15 @@ __kdump_ssh_server_location: "{{ kdump_target.location |
                                  regex_replace('.*@(.*)$', '\\1')
                                  if kdump_target.location is defined
                                  else kdump_ssh_server }}"
+
+__kdump_packages:
+  - "kexec-tools"
+
+__kdump_required_facts:
+  - all_ipv4_addresses
+  - all_ipv6_addresses
+  - default_ipv4
+  - distribution
+  - distribution_major_version
+  - distribution_version
+  - user_id


### PR DESCRIPTION
Some users use `gather_facts: false` in their playbooks.  This changes
the role to work in that case, by gathering only the facts it requires
to run.
CI testing can be sped up by creating a snapshot image pre-installed
with packages.  tests/setup-snapshot.yml can be used by a CI system
to do this.
Use `public: true` with the certificate role because the test uses
internal variables from that role.
