### PR TITLE
Revert "Use tox-lsr 2.14.1; use py39 for ansible related checks; use podman instead of docker (#114)"

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -4,7 +4,7 @@ on:  # yamllint disable-line rule:truthy
   - pull_request
   - push
 env:
-  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.14.1"
+  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.13.0"
   LSR_ANSIBLE_TEST_DOCKER: "true"
   LSR_ANSIBLES: 'ansible==2.9.*'
   LSR_MSCENARIOS: default
@@ -43,10 +43,6 @@ jobs:
           sudo apt-get install -y git
           pip install "$TOX_LSR"
           lsr_ci_preinstall
-          if [ "${{ matrix.pyver_os.os }}" = ubuntu-latest ]; then
-              sudo apt-get purge -y moby-cli
-              sudo apt-get install -y podman-docker
-          fi
       - name: Run tox tests
         run: |
           set -euxo pipefail
@@ -55,8 +51,8 @@ jobs:
           case "$toxpyver" in
           27) toxenvs="${toxenvs},coveralls,flake8,pylint" ;;
           36) toxenvs="${toxenvs},coveralls,black,yamllint,shellcheck" ;;
-          38) toxenvs="${toxenvs},coveralls" ;;
-          39) toxenvs="${toxenvs},coveralls,ansible-lint,ansible-managed-var-comment,ansible-plugin-scan,collection,ansible-test" ;;
+          38) toxenvs="${toxenvs},coveralls,ansible-lint,ansible-plugin-scan,collection,ansible-test" ;;
+          39) toxenvs="${toxenvs},coveralls,ansible-managed-var-comment" ;;
           310) toxenvs="${toxenvs},coveralls,check-meta-versions" ;;
           311) toxenvs="${toxenvs},coveralls" ;;
           esac


### PR DESCRIPTION
This reverts commit dc41ad2ebac1c32bdd9d3630b11299f20cbc6727.
