### PR TITLE
Fingerprint RHEL System Role managed config files

### DIFF
--- a/templates/kdump.conf.j2
+++ b/templates/kdump.conf.j2
@@ -1,4 +1,5 @@
 {{ ansible_managed | comment }}
+{{ "system_role:kdump" | comment(prefix="", postfix="") }}
 
 {% if kdump_target %}
 {% if kdump_target.type == "ssh" %}

--- a/templates/kdump.j2
+++ b/templates/kdump.j2
@@ -1,4 +1,5 @@
 {{ ansible_managed | comment }}
+{{ "system_role:kdump" | comment(prefix="", postfix="") }}
 
 {% if ansible_distribution == 'Fedora' or (ansible_os_family == 'RedHat' and ansible_distribution_version|int >= 7) %}
 


### PR DESCRIPTION
Add role name to the generated config files.
```
# system_role:kdump
```
Note: This information is provided to help customers identify that it was generated by System Roles. It may also be used for future analysis.