### PR TITLE
ansible-lint - use changed_when even for conditional execution

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,6 +60,10 @@
     - kdump_reboot_required | bool
     - ansible_facts['distribution'] in ['RedHat', 'CentOS']
     - ansible_facts['distribution_major_version'] | int >= 9
+  changed_when:
+    - kdump_reboot_required | bool
+    - ansible_facts['distribution'] in ['RedHat', 'CentOS']
+    - ansible_facts['distribution_major_version'] | int >= 9
 
 - name: Fail if reboot is required and kdump_reboot_ok is false
   fail:

--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -7,6 +7,7 @@
 - name: Create key
   command: "/usr/bin/ssh-keygen -t rsa -f {{ kdump_sshkey }} -N '' "
   when: not sshkey_stats.stat.exists
+  changed_when: true
 
 - name: Fetch key
   slurp:


### PR DESCRIPTION
ansible-lint now requires `changed_when` even where the command
is conditionally executed
