### PR TITLE
fix: use failure_action instead of default on EL9 and later

### DIFF
--- a/templates/kdump.conf.j2
+++ b/templates/kdump.conf.j2
@@ -18,11 +18,13 @@ path {{ kdump_path }}
 {% if kdump_core_collector %}
 core_collector {{ kdump_core_collector }}
 {% endif %}
-default {{ kdump_system_action }}
 
 {% if ansible_facts['distribution'] in ['RedHat', 'CentOS', 'Fedora'] %}
 {% if ansible_facts['distribution_major_version'] | int >= 9 %}
 auto_reset_crashkernel {{ kdump_auto_reset_crashkernel | bool | ternary("yes", "no") }}
+failure_action {{ kdump_system_action }}
+{% else %}
+default {{ kdump_system_action }}
 {% endif %}
 {% if ansible_facts['distribution_major_version'] | int >= 7 %}
 {% if kdump_dracut_args %}


### PR DESCRIPTION
Cause: kdump uses the configuration option 'failure_action' instead
of 'default' on EL9 and later.

Consequence: kdump prints a warning to the logs:
kdump: warning: option 'default' was renamed 'failure_action' and will be removed in the future.
please update /etc/kdump.conf to use option 'failure_action' instead.

Fix: Use 'failure_action' on EL9 and later.

Result: kdump works normally on EL9 and later with no warnings to the logs.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
