### PR TITLE
test: call handlers to refresh kdump before calling role again

### DIFF
--- a/tests/tests_default_reboot.yml
+++ b/tests/tests_default_reboot.yml
@@ -13,6 +13,9 @@
         name: linux-system-roles.kdump
         public: true
 
+    - name: Notify and run handlers
+      meta: flush_handlers
+
     - name: Check generated files for ansible_managed, fingerprint
       include_tasks: tasks/check_header.yml
       vars:


### PR DESCRIPTION
Call the handlers before calling the role again to refresh the configuration.
The role will sometimes fail if the configuration has not been properly
flushed by the handlers before calling the role again.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
