### PR TITLE
fix: do not fail if authorized_keys not found

### DIFF
--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -24,8 +24,7 @@
 - name: Set authorized_keys file path
   set_fact:
     __kdump_authorized_keys_path: "{{
-      __kdump_ssh_user_info.home ~ '/.ssh/authorized_keys'
-    }}"
+      __kdump_ssh_user_info.home ~ '/.ssh/authorized_keys' }}"
 
 - name: Get the authorized_keys file for the user
   stat:
@@ -44,14 +43,12 @@
 
 - name: Write new authorized_keys if needed
   vars:
+    # note - Cg== is the newline character in base64
     __kdump_authorized_keys_lines: "{{
-      (__kdump_authorized_keys.content | b64decode).split('\n') |
-      reject('match', '^$') | list
-      if __kdump_authorized_keys is defined else []
-    }}"
+      (__kdump_authorized_keys.content | d('Cg==') | b64decode).split('\n') |
+      reject('match', '^$') | list }}"
     __kdump_authorized_keys_lines_new: "{{
-      __kdump_authorized_keys_lines | union([keydata.content | b64decode])
-    }}"
+      __kdump_authorized_keys_lines | union([keydata.content | b64decode]) }}"
   copy:
     content: "{{ (__kdump_authorized_keys_lines_new | join('\n')) ~ '\n' }}"
     dest: "{{ __kdump_authorized_keys_file.stat.path |


### PR DESCRIPTION
Cause: The evaluation of `__kdump_authorized_keys is defined` was happening
after the evaluation of `(__kdump_authorized_keys.content ...)`.  I guess
the parentheses cause the evaluation to happen first, regardless of the
`if` conditional.

Consequence: If authorized_keys were not found, the role would attempt to
evaluate the undefined `__kdump_authorized_keys` and fail.

Fix: Use the `defined` filter `d` with `__kdump_authorized_keys` to define
the value as an empty line, and omit the `if` clause.

Result: The role does not fail if authorized_keys are missing.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
