### PR TITLE
fix: Write new authorized_keys if needed is not idempotent

### DIFF
--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -47,17 +47,17 @@
     __kdump_authorized_keys_lines: "{{
       (__kdump_authorized_keys.content | d('Cg==') | b64decode).split('\n') |
       reject('match', '^$') | list }}"
-    __kdump_authorized_keys_lines_new: "{{
-      __kdump_authorized_keys_lines | union([keydata.content | b64decode]) }}"
+    __kdump_new_key: "{{ keydata.content | b64decode | trim }}"
   copy:
-    content: "{{ (__kdump_authorized_keys_lines_new | join('\n')) ~ '\n' }}"
+    content: "{{ ((__kdump_authorized_keys_lines + [__kdump_new_key]) |
+      join('\n')) ~ '\n' }}"
     dest: "{{ __kdump_authorized_keys_file.stat.path |
               d(__kdump_authorized_keys_path) }}"
     group: "{{ __kdump_authorized_keys_file.stat.group | d(kdump_ssh_user) }}"
     owner: "{{ __kdump_authorized_keys_file.stat.owner | d(kdump_ssh_user) }}"
     mode: "{{ __kdump_authorized_keys_file.stat.mode | d('0600') }}"
   delegate_to: "{{ kdump_ssh_server }}"
-  when: __kdump_authorized_keys_lines != __kdump_authorized_keys_lines_new
+  when: not __kdump_new_key in __kdump_authorized_keys_lines
 
 - name: Fetch the servers public key
   slurp:

--- a/tests/tests_ssh_reboot.yml
+++ b/tests/tests_ssh_reboot.yml
@@ -85,3 +85,41 @@
     - name: Run the role and reboot if necessary
       include_role:
         name: linux-system-roles.kdump
+
+    - name: Get userinfo for {{ kdump_ssh_user }}
+      user:
+        name: "{{ kdump_ssh_user }}"
+        state: present
+      register: __user_info
+      delegate_to: "{{ kdump_ssh_server }}"
+
+    - name: Set authorized_keys file path
+      set_fact:
+        __authorized_keys_path: "{{
+          __user_info.home ~ '/.ssh/authorized_keys' }}"
+
+    - name: Get the authorized_keys file for the user
+      stat:
+        path: "{{ __authorized_keys_path }}"
+      register: __authorized_keys_file
+      delegate_to: "{{ kdump_ssh_server }}"
+
+    - name: Get the authorized_keys contents
+      slurp:
+        src: "{{ __authorized_keys_file.stat.path }}"
+      delegate_to: "{{ kdump_ssh_server }}"
+      register: __authorized_keys_before
+
+    - name: Run the role again
+      include_role:
+        name: linux-system-roles.kdump
+
+    - name: Get the authorized_keys contents after
+      slurp:
+        src: "{{ __authorized_keys_file.stat.path }}"
+      delegate_to: "{{ kdump_ssh_server }}"
+      register: __authorized_keys_after
+
+    - name: Assert no changes to authorized_keys
+      assert:
+        that: __authorized_keys_before == __authorized_keys_after


### PR DESCRIPTION
Cause: The new key content had an extra newline at the end.

Consequence: The test to see if the new key content was in the
current authorized_key list failed, so the key was added every
time, and the task was not idempotent.

Fix: Ensure the new key value has no extra newline. Use a simple
list `in` test to see if the new value is in the existing list.

Result: The task to write authorized_keys is idempotent.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
