### PR TITLE
fix: ensure .ssh directory exists for kdump_ssh_user on kdump_ssh_server

### DIFF
--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -21,10 +21,19 @@
   register: __kdump_ssh_user_info
   delegate_to: "{{ kdump_ssh_server }}"
 
+- name: Set ssh file path
+  set_fact:
+    __kdump_ssh_path: "{{ __kdump_ssh_user_info.home ~ '/.ssh' }}"
+
 - name: Set authorized_keys file path
   set_fact:
-    __kdump_authorized_keys_path: "{{
-      __kdump_ssh_user_info.home ~ '/.ssh/authorized_keys' }}"
+    __kdump_authorized_keys_path: "{{ __kdump_ssh_path ~ '/authorized_keys' }}"
+
+- name: Get the ssh directory for the user
+  stat:
+    path: "{{ __kdump_ssh_path }}"
+  register: __kdump_ssh_path_stat
+  delegate_to: "{{ kdump_ssh_server }}"
 
 - name: Get the authorized_keys file for the user
   stat:
@@ -41,23 +50,38 @@
     - __kdump_authorized_keys_file.stat.isreg is defined
     - __kdump_authorized_keys_file.stat.isreg
 
-- name: Write new authorized_keys if needed
+- name: Handle authorized_keys update if needed
   vars:
     # note - Cg== is the newline character in base64
     __kdump_authorized_keys_lines: "{{
       (__kdump_authorized_keys.content | d('Cg==') | b64decode).split('\n') |
       reject('match', '^$') | list }}"
     __kdump_new_key: "{{ keydata.content | b64decode | trim }}"
-  copy:
-    content: "{{ ((__kdump_authorized_keys_lines + [__kdump_new_key]) |
-      join('\n')) ~ '\n' }}"
-    dest: "{{ __kdump_authorized_keys_file.stat.path |
-              d(__kdump_authorized_keys_path) }}"
-    group: "{{ __kdump_authorized_keys_file.stat.group | d(kdump_ssh_user) }}"
-    owner: "{{ __kdump_authorized_keys_file.stat.owner | d(kdump_ssh_user) }}"
-    mode: "{{ __kdump_authorized_keys_file.stat.mode | d('0600') }}"
-  delegate_to: "{{ kdump_ssh_server }}"
   when: not __kdump_new_key in __kdump_authorized_keys_lines
+  delegate_to: "{{ kdump_ssh_server }}"
+  block:
+    - name: Ensure ssh directory for authorized_keys if needed
+      file:
+        path: "{{ __kdump_ssh_path_stat.stat.path |
+          d(__kdump_ssh_path) }}"
+        state: directory
+        group: "{{ __kdump_ssh_path_stat.stat.gr_name |
+          d(kdump_ssh_user) }}"
+        owner: "{{ __kdump_ssh_path_stat.stat.pw_name |
+          d(kdump_ssh_user) }}"
+        mode: "{{ __kdump_ssh_path_stat.stat.mode | d('0700') }}"
+
+    - name: Write new authorized_keys if needed
+      copy:
+        content: "{{ ((__kdump_authorized_keys_lines + [__kdump_new_key]) |
+          join('\n')) ~ '\n' }}"
+        dest: "{{ __kdump_authorized_keys_file.stat.path |
+                  d(__kdump_authorized_keys_path) }}"
+        group: "{{ __kdump_authorized_keys_file.stat.gr_name |
+          d(kdump_ssh_user) }}"
+        owner: "{{ __kdump_authorized_keys_file.stat.pw_name |
+          d(kdump_ssh_user) }}"
+        mode: "{{ __kdump_authorized_keys_file.stat.mode | d('0600') }}"
 
 - name: Fetch the servers public key
   slurp:

--- a/tests/tests_ssh_reboot.yml
+++ b/tests/tests_ssh_reboot.yml
@@ -33,8 +33,6 @@
     # This is the outside address. Ansible will connect to it to
     # copy the ssh key.
     kdump_ssh_server: "{{ kdump_test_ssh_server_outside }}"
-    kdump_ssh_user: >-
-      {{ hostvars[kdump_test_ssh_server_outside]['ansible_user_id'] }}
     kdump_path: /tmp/test
     kdump_target:
       type: ssh
@@ -65,6 +63,21 @@
       delegate_to: "{{ kdump_test_ssh_server_outside }}"
       delegate_facts: true
 
+    - name: Create a kdump user on kdump_ssh_server
+      user:
+        name: kdump_ssh_user
+        uid: 1189
+      register: __user_info
+      delegate_to: "{{ kdump_ssh_server }}"
+
+    - name: Set kdump_ssh_user, sshkey, auth keys
+      set_fact:
+        kdump_ssh_user: kdump_ssh_user
+        __ssh_dir: "{{
+          __user_info.home ~ '/.ssh' }}"
+        __authorized_keys_path: "{{
+          __user_info.home ~ '/.ssh/authorized_keys' }}"
+
     - name: Print message that this test is skipped on EL 6
       debug:
         msg: Skipping the test on EL 6 because control node == managed node
@@ -86,17 +99,14 @@
       include_role:
         name: linux-system-roles.kdump
 
-    - name: Get userinfo for {{ kdump_ssh_user }}
-      user:
-        name: "{{ kdump_ssh_user }}"
-        state: present
-      register: __user_info
-      delegate_to: "{{ kdump_ssh_server }}"
+    - name: Flush handlers
+      meta: flush_handlers
 
-    - name: Set authorized_keys file path
-      set_fact:
-        __authorized_keys_path: "{{
-          __user_info.home ~ '/.ssh/authorized_keys' }}"
+    - name: Get the ssh dir for the user
+      stat:
+        path: "{{ __ssh_dir }}"
+      register: __ssh_dir_stat_before
+      delegate_to: "{{ kdump_ssh_server }}"
 
     - name: Get the authorized_keys file for the user
       stat:
@@ -107,19 +117,37 @@
     - name: Get the authorized_keys contents
       slurp:
         src: "{{ __authorized_keys_file.stat.path }}"
-      delegate_to: "{{ kdump_ssh_server }}"
       register: __authorized_keys_before
+      delegate_to: "{{ kdump_ssh_server }}"
 
     - name: Run the role again
       include_role:
         name: linux-system-roles.kdump
 
+    - name: Delete user
+      user:
+        name: "{{ kdump_ssh_user }}"
+        state: absent
+
     - name: Get the authorized_keys contents after
       slurp:
         src: "{{ __authorized_keys_file.stat.path }}"
-      delegate_to: "{{ kdump_ssh_server }}"
       register: __authorized_keys_after
+      delegate_to: "{{ kdump_ssh_server }}"
 
     - name: Assert no changes to authorized_keys
       assert:
         that: __authorized_keys_before == __authorized_keys_after
+
+    - name: Get the ssh dir for the user after
+      stat:
+        path: "{{ __ssh_dir }}"
+      register: __ssh_dir_stat_after
+      delegate_to: "{{ kdump_ssh_server }}"
+
+    - name: Assert no changes to ssh dir
+      assert:
+        that:
+          - __ssh_dir_stat_before.stat.mode == __ssh_dir_stat_after.stat.mode
+          - __ssh_dir_stat_before.stat.uid == __ssh_dir_stat_after.stat.uid
+          - __ssh_dir_stat_before.stat.gid == __ssh_dir_stat_after.stat.gid


### PR DESCRIPTION
Cause: The role does not ensure that the .ssh directory exists for
the kdump_ssh_user on kdump_ssh_server.

Consequence: The role will fail attempting to update the .ssh/authorized_keys
file for the kdump_ssh_user on kdump_ssh_server.

Fix: Ensure the .ssh directory exists for the kdump_ssh_user on kdump_ssh_server.

Result: The role does not fail attempting to update the .ssh/authorized_keys
file for the kdump_ssh_user on kdump_ssh_server.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
