### PR TITLE
fix: retry read of kexec_crash_size

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,6 +34,7 @@
   slurp:
     src: /sys/kernel/kexec_crash_size
   register: kexec_crash_size
+  until: kexec_crash_size is success
 
 - name: Set the kdump_reboot_required fact
   set_fact:


### PR DESCRIPTION
Cause: Reading /sys/kernel/kexec_crash_size can report errno 16 - device busy.

Consequence: The role fails because it cannot read the value.

Fix: Retry the read.

Result: The role does not fail if /sys/kernel/kexec_crash_size is busy.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
