### PR TITLE
test: delete kdump user last, retry until success

### DIFF
--- a/tests/tests_ssh_reboot.yml
+++ b/tests/tests_ssh_reboot.yml
@@ -124,11 +124,6 @@
       include_role:
         name: linux-system-roles.kdump
 
-    - name: Delete user
-      user:
-        name: "{{ kdump_ssh_user }}"
-        state: absent
-
     - name: Get the authorized_keys contents after
       slurp:
         src: "{{ __authorized_keys_file.stat.path }}"
@@ -151,3 +146,10 @@
           - __ssh_dir_stat_before.stat.mode == __ssh_dir_stat_after.stat.mode
           - __ssh_dir_stat_before.stat.uid == __ssh_dir_stat_after.stat.uid
           - __ssh_dir_stat_before.stat.gid == __ssh_dir_stat_after.stat.gid
+
+    - name: Delete user
+      user:
+        name: "{{ kdump_ssh_user }}"
+        state: absent
+      register: __user_delete
+      until: __user_delete is success


### PR DESCRIPTION
Some tests fail like this:
```
TASK [Delete user] *************************************************************
fatal: [/tmp/tmp.cgsy6Vmlnz/RHEL_8_9_TESTING.qcow2]: FAILED! => {
    "changed": false,
    "name": "kdump_ssh_user",
    "rc": 8
}

userdel: user kdump_ssh_user is currently used by process 23050
```

Move the deletion of the user to the last part of the test, and retry
until success or timeout.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
