### PR TITLE
ci: update github action checkout to v4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,6 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: monthly
+      interval: weekly
+    commit-message:
+      prefix: ci

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Ansible Role: Kernel Crash Dump
 
-[![ansible-lint.yml](https://github.com/linux-system-roles/kdump/actions/workflows/ansible-lint.yml/badge.svg)](https://github.com/linux-system-roles/kdump/actions/workflows/ansible-lint.yml) [![ansible-test.yml](https://github.com/linux-system-roles/kdump/actions/workflows/ansible-test.yml/badge.svg)](https://github.com/linux-system-roles/kdump/actions/workflows/ansible-test.yml) [![markdownlint.yml](https://github.com/linux-system-roles/kdump/actions/workflows/markdownlint.yml/badge.svg)](https://github.com/linux-system-roles/kdump/actions/workflows/markdownlint.yml) [![woke.yml](https://github.com/linux-system-roles/kdump/actions/workflows/woke.yml/badge.svg)](https://github.com/linux-system-roles/kdump/actions/workflows/woke.yml)
+[![woke.yml](https://github.com/linux-system-roles/kdump/actions/workflows/woke.yml/badge.svg)](https://github.com/linux-system-roles/kdump/actions/workflows/woke.yml) [![markdownlint.yml](https://github.com/linux-system-roles/kdump/actions/workflows/markdownlint.yml/badge.svg)](https://github.com/linux-system-roles/kdump/actions/workflows/markdownlint.yml) [![ansible-test.yml](https://github.com/linux-system-roles/kdump/actions/workflows/ansible-test.yml/badge.svg)](https://github.com/linux-system-roles/kdump/actions/workflows/ansible-test.yml) [![ansible-lint.yml](https://github.com/linux-system-roles/kdump/actions/workflows/ansible-lint.yml/badge.svg)](https://github.com/linux-system-roles/kdump/actions/workflows/ansible-lint.yml)
 
 An ansible role which configures kdump.
 


### PR DESCRIPTION
Use v4 github action checkout
Update dependabot to include the "ci: " prefix in commit/pr titles
for PR title checking.
Tell dependabot to check weekly instead of monthly

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
