### PR TITLE
test: clean up kdump_path

### DIFF
--- a/tests/tests_ssh.yml
+++ b/tests/tests_ssh.yml
@@ -35,7 +35,7 @@
     kdump_ssh_server: "{{ kdump_test_ssh_server_outside }}"
     kdump_ssh_user: >-
       {{ hostvars[kdump_test_ssh_server_outside]['ansible_user_id'] }}
-    kdump_path: /tmp/test
+    kdump_path: /tmp/tests_ssh
     kdump_target:
       type: ssh
       # This is the ssh dump server address visible from inside
@@ -93,3 +93,9 @@
                 'Reboot is required to apply changes.' in
                 ansible_failed_result.msg
               - kdump_reboot_required | bool
+
+    - name: Cleanup kdump_path
+      file:
+        path: "{{ kdump_path }}"
+        state: absent
+      delegate_to: "{{ kdump_ssh_server }}"

--- a/tests/tests_ssh_reboot.yml
+++ b/tests/tests_ssh_reboot.yml
@@ -33,7 +33,7 @@
     # This is the outside address. Ansible will connect to it to
     # copy the ssh key.
     kdump_ssh_server: "{{ kdump_test_ssh_server_outside }}"
-    kdump_path: /tmp/test
+    kdump_path: /tmp/tests_ssh_reboot
     kdump_target:
       type: ssh
       # This is the ssh dump server address visible from inside
@@ -169,3 +169,9 @@
         state: absent
       register: __user_delete
       until: __user_delete is success
+
+    - name: Cleanup kdump_path
+      file:
+        path: "{{ kdump_path }}"
+        state: absent
+      delegate_to: "{{ kdump_ssh_server }}"


### PR DESCRIPTION
Use a unique value of `kdump_path` for each test so we don't have
any conflicts.
Ensure `kdump_path` is removed after the test.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
