### PR TITLE
fix: el10 kdump role should depend on kdump-utils

### DIFF
--- a/.ostree/packages-runtime-CentOS-10.txt
+++ b/.ostree/packages-runtime-CentOS-10.txt
@@ -1,0 +1,1 @@
+kdump-utils

--- a/.ostree/packages-runtime-RedHat-10.txt
+++ b/.ostree/packages-runtime-RedHat-10.txt
@@ -1,0 +1,1 @@
+kdump-utils

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -16,3 +16,18 @@
     - name: Set flag to indicate system is ostree
       set_fact:
         __kdump_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
+
+- name: Set platform/version specific variables
+  include_vars: "{{ __vars_file }}"
+  loop:
+    - "{{ ansible_facts['os_family'] }}.yml"
+    - "{{ ansible_facts['distribution'] }}.yml"
+    - >-
+      {{ ansible_facts['distribution'] ~ '_' ~
+      ansible_facts['distribution_major_version'] }}.yml
+    - >-
+      {{ ansible_facts['distribution'] ~ '_' ~
+      ansible_facts['distribution_version'] }}.yml
+  vars:
+    __vars_file: "{{ role_path }}/vars/{{ item }}"
+  when: __vars_file is file

--- a/vars/CentOS_10.yml
+++ b/vars/CentOS_10.yml
@@ -1,0 +1,7 @@
+---
+__kdump_packages:
+  - grubby
+  - iproute  # for fact gathering for ip facts
+  - kexec-tools
+  - kdump-utils
+  - openssh-clients

--- a/vars/RedHat_10.yml
+++ b/vars/RedHat_10.yml
@@ -1,0 +1,7 @@
+---
+__kdump_packages:
+  - grubby
+  - iproute  # for fact gathering for ip facts
+  - kexec-tools
+  - kdump-utils
+  - openssh-clients


### PR DESCRIPTION
Cause: The kdump tools in el10 are split into kexec-tools and
kdump-utils.

Consequence: The kdump role does not have all of the packages
required.

Fix: Install both kexec-tools and kdump-utils on el10.

Result: The kdump system role has all of the packages and
tools required at runtime.

Jira issue: https://issues.redhat.com/browse/RHEL-40071
