### PR TITLE
test: run handlers after each role invocation to ensure role works

### DIFF
--- a/tests/tests_default_reboot.yml
+++ b/tests/tests_default_reboot.yml
@@ -81,6 +81,9 @@
       include_role:
         name: linux-system-roles.kdump
 
+    - name: Notify and run handlers again
+      meta: flush_handlers
+
     - name: Check for crashkernel, grubby settings again
       when: is_el9 or is_el7_or_el8
       block:

--- a/tests/tests_ssh.yml
+++ b/tests/tests_ssh.yml
@@ -94,6 +94,9 @@
                 ansible_failed_result.msg
               - kdump_reboot_required | bool
 
+    - name: Notify and run handlers
+      meta: flush_handlers
+
     - name: Cleanup kdump_path
       file:
         path: "{{ kdump_path }}"

--- a/tests/tests_ssh_reboot.yml
+++ b/tests/tests_ssh_reboot.yml
@@ -140,6 +140,9 @@
       include_role:
         name: linux-system-roles.kdump
 
+    - name: Notify and run handlers again
+      meta: flush_handlers
+
     - name: Get the authorized_keys contents after
       slurp:
         src: "{{ __authorized_keys_file.stat.path }}"


### PR DESCRIPTION
This will also help with cleanup - removing files used by kdump
before the handlers are run causes test errors.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Tests:
- Add meta: flush_handlers steps in tests_default_reboot.yml, tests_ssh.yml, and tests_ssh_reboot.yml to run handlers after role invocation for cleanup stability.